### PR TITLE
Temporarily disable odbc in ci

### DIFF
--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -70,10 +70,10 @@ runs:
           --with-lmdb \
           --with-qdbm \
           --with-snmp \
-          --with-unixODBC \
+          `#--with-unixODBC` \
           --with-imap \
           --with-imap-ssl \
-          --with-pdo-odbc=unixODBC,/usr \
+          `#--with-pdo-odbc=unixODBC,/usr` \
           --with-pdo-oci=shared,instantclient,/opt/oracle/instantclient \
           --with-oci8=shared,instantclient,/opt/oracle/instantclient \
           --with-config-file-path=/etc \


### PR DESCRIPTION
The unixodbc.h header is suddenly missing.