### PR TITLE
Re-enable -Wstrict-aliasing

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -202,7 +202,7 @@ else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi
 
-test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare $CFLAGS"
+test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare $CFLAGS"
 dnl Check if compiler supports -Wno-clobbered (only GCC)
 AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="-Wno-clobbered $CFLAGS", , [-Werror])
 dnl Check for support for implicit fallthrough level 1, also add after previous CFLAGS as level 3 is enabled in -Wextra

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1799,11 +1799,11 @@ PHP_FUNCTION(mysqli_stmt_attr_get)
 			"MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, "
 			"MYSQLI_STMT_ATTR_PREFETCH_ROWS, or STMT_ATTR_CURSOR_TYPE");
 		RETURN_THROWS();
-    }
-
+	}
 
 	if (attr == STMT_ATTR_UPDATE_MAX_LENGTH)
-		value = *((my_bool *)&value);
+		value = (my_bool)value;
+
 	RETURN_LONG((unsigned long)value);
 }
 /* }}} */


### PR DESCRIPTION
We're not disabling -fstrict-aliasing to it's better to keep this warning.