### PR TITLE
Enable GitHub actions cancel-in-progress for PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,9 @@ on:
   pull_request:
     branches:
       - '**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.url || github.run_id }}
+  cancel-in-progress: true
 env:
   CC: ccache gcc
   CXX: ccache g++


### PR DESCRIPTION
Pushing many commits to a pull request in a short amount of time can stall the merge builds and also wastes energy unnecessarily. github.head_ref is only set for pull requests. For the main branches we fall back to github.run_id which is unique and always available.