### PR TITLE
Add apt retry

### DIFF
--- a/.github/actions/apt-x32/action.yml
+++ b/.github/actions/apt-x32/action.yml
@@ -7,6 +7,7 @@ runs:
         set -x
 
         export DEBIAN_FRONTEND=noninteractive
+        echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
         dpkg --add-architecture i386
         apt-get update -y | true
         # TODO: Reenable postgresql + postgresql-contrib packages once they work again.

--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -6,6 +6,7 @@ runs:
       run: |
         set -x
 
+        echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
         sudo apt-get update
         sudo apt-get install \
           bison \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -563,6 +563,7 @@ jobs:
           ref: ${{ matrix.branch.ref }}
       - name: apt
         run: |
+          echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
           sudo apt-get update -y | true
           sudo apt install bison re2c
       - name: Setup


### PR DESCRIPTION
Builds occasionally fail due to apt failing to download dependencies.