### PR TITLE
[RFC] Flip scope lookup order for ns function calls

### DIFF
--- a/Zend/tests/bug74164.phpt
+++ b/Zend/tests/bug74164.phpt
@@ -9,12 +9,13 @@ set_error_handler(function ($type, $msg) {
     throw new \Exception($msg);
 });
 
-call_user_func(function (array &$ref) {var_dump("xxx");}, 'not_an_array_variable');
+$fn = 'call_user_func';
+$fn(function (array &$ref) {var_dump("xxx");}, 'not_an_array_variable');
 ?>
 --EXPECTF--
 Fatal error: Uncaught Exception: {closure:%s:%d}(): Argument #1 ($ref) must be passed by reference, value given in %s:%d
 Stack trace:
-#0 [internal function]: {closure:%s:%d}(2, '%s', '%s', 9)
+#0 [internal function]: {closure:%s:%d}(2, '%s', '%s', 10)
 #1 %sbug74164.php(%d): call_user_func(%s)
 #2 {main}
   thrown in %sbug74164.php on line %d

--- a/Zend/tests/call_user_func_strict_arginfo_check.phpt
+++ b/Zend/tests/call_user_func_strict_arginfo_check.phpt
@@ -7,7 +7,8 @@ declare(strict_types=1);
 namespace Foo;
 
 // strlen() will be called with strict_types=0, so this is legal.
-var_dump(call_user_func('strlen', false));
+$fn = 'call_user_func';
+var_dump($fn('strlen', false));
 
 ?>
 --EXPECT--

--- a/Zend/tests/frameless_jmp_004.phpt
+++ b/Zend/tests/frameless_jmp_004.phpt
@@ -13,5 +13,4 @@ declare_local_class_exists();
 var_dump(CLASS_EXISTS('Foo'));
 ?>
 --EXPECT--
-string(16) "Foo\class_exists"
-bool(true)
+bool(false)

--- a/Zend/tests/ns_013.phpt
+++ b/Zend/tests/ns_013.phpt
@@ -11,4 +11,4 @@ function strlen($x) {
 echo strlen("Hello"),"\n";
 ?>
 --EXPECT--
-test\ns1\strlen
+5

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -25,8 +25,8 @@ function main() {
     $data['Zend/bench.php JIT'] = runBench(true);
     $data['Symfony Demo 2.2.3'] = runSymfonyDemo(false);
     $data['Symfony Demo 2.2.3 JIT'] = runSymfonyDemo(true);
-    $data['Wordpress 6.2'] = runWordpress(false);
-    $data['Wordpress 6.2 JIT'] = runWordpress(true);
+    // $data['Wordpress 6.2'] = runWordpress(false);
+    // $data['Wordpress 6.2 JIT'] = runWordpress(true);
     $result = json_encode($data, JSON_PRETTY_PRINT) . "\n";
 
     fwrite(STDOUT, $result);

--- a/ext/reflection/tests/ReflectionFiber_notrace_2.phpt
+++ b/ext/reflection/tests/ReflectionFiber_notrace_2.phpt
@@ -5,7 +5,8 @@ ReflectionFiber should not segfault when inspecting fibers where the previous st
 
 namespace test;
 
-$f = new \Fiber(fn() => call_user_func(["Fiber", "suspend"]));
+$fn = 'call_user_func';
+$f = new \Fiber(fn() => $fn(["Fiber", "suspend"]));
 $f->start();
 
 $reflection = new \ReflectionFiber($f);
@@ -17,7 +18,7 @@ var_dump($reflection->getTrace());
 ?>
 --EXPECTF--
 string(%d) "%sReflectionFiber_notrace_2.php"
-int(5)
+int(6)
 array(3) {
   [0]=>
   array(4) {
@@ -36,7 +37,7 @@ array(3) {
     ["file"]=>
     string(%d) "%sReflectionFiber_notrace_2.php"
     ["line"]=>
-    int(5)
+    int(6)
     ["function"]=>
     string(14) "call_user_func"
     ["args"]=>

--- a/ext/zend_test/tests/observer_call_user_func_03.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_03.phpt
@@ -22,8 +22,9 @@ namespace Test {
         echo 'my_function called' . PHP_EOL;
     }
 
-    call_user_func('Test\\MyClass::myMethod');
-    call_user_func('Test\\my_function');
+    $fn = 'call_user_func';
+    $fn('Test\\MyClass::myMethod');
+    $fn('Test\\my_function');
 }
 ?>
 --EXPECTF--

--- a/ext/zend_test/tests/observer_call_user_func_04.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_04.phpt
@@ -22,8 +22,9 @@ namespace Test {
         echo 'my_function ' . $msg . PHP_EOL;
     }
 
-    call_user_func_array('Test\\MyClass::myMethod', ['called']);
-    call_user_func_array('Test\\my_function', ['called']);
+    $fn = 'call_user_func_array';
+    $fn('Test\\MyClass::myMethod', ['called']);
+    $fn('Test\\my_function', ['called']);
 }
 ?>
 --EXPECTF--

--- a/sapi/phpdbg/tests/print_001.phpt
+++ b/sapi/phpdbg/tests/print_001.phpt
@@ -29,9 +29,9 @@ Foo\Bar::Foo:
      ; (lines=5, args=1, vars=1, tmps=%d)
      ; %s:5-7
 L0005 0000 CV0($bar) = RECV 1
-L0006 0001 INIT_NS_FCALL_BY_NAME 1 string("Foo\\var_dump")
-L0006 0002 SEND_VAR_EX CV0($bar) 1
-L0006 0003 DO_FCALL
+L0006 0001 INIT_FCALL %d %d string("var_dump")
+L0006 0002 SEND_VAR CV0($bar) 1
+L0006 0003 DO_ICALL
 L0007 0004 RETURN null
 
 Foo\Bar::baz:


### PR DESCRIPTION
The aim of this RFC is to improve the performance of global, internal function calls inside namespaced code without the need of prefixing all calls with `\`, or explicitly `use`-ing them.

Currently, a non-fq function call name is looked up in local scope, and then in global scope. For example, a call to `var_dump()` inside the `App` namespace will first look for `\App\var_dump()`, and only then for `\var_dump()`. It is a well-known optimization to prefix the call with `\` to avoid the local lookup.

However, for internal calls this goes a few steps further. Particularly:

* Some internal functions can be evaluated at compile-time if their arguments are known at compile-time.
* Some internal functions have specialized opcodes that execute faster than function calls (e.g. `strlen()`).
* Some internal functions have "frameless handlers" that don't require pushing a stack frame.
* All internal function calls can avoid an initial function lookup by name and replace it with a cheaper offset into the function table.
* Known arguments can be sent more efficiently because of known by-value/by-reference passing.

All of these optimizations are limited to functions known at compile-time. Because we don't know if `var_dump()` refers to `\App\var_dump()` or `\var_dump()`, we cannot apply any of these optimizations.

However, if we were to tweak the lookup to _first_ check in global scope, and only then in local scope, we can assume that any function found in global scope is the function that will be executed at run-time. There are a couple of downsides:

* Unqualified calls in namespaces will be slightly slower because they now involve checking global scope first. I believe that unqualified, global function calls are much more common than relative calls to functions in the same namespace, so this should still result in a net positive. You can still avoid this cost by including the local function with use. Functions that happen to share the name of a global function MUST be adjusted, or the wrong function will be called.
* Introducing new functions in the global namespace now is a BC break for unqualified function calls to namespaced functions of the same name. This is unfortunate, but hopefully rare. Since new functions are only introduced in minor/major versions, this should be manageable.

Valgrind shows a 0.91% reduction in instructions for Symfony Demo. I'm not sure yet how this translates to real world performance.