### PR TITLE
Improve performance of property hooks

### DIFF
--- a/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
+++ b/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
@@ -4,6 +4,9 @@ Attempted read/write of backing value in a delegated method throws
 <?php
 if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
 ?>
+--INI--
+; The test may use a large amount of memory on systems with a large stack limit
+memory_limit=2G
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
+++ b/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Attempted read/write of backing value in a delegated method throws
+--SKIPIF--
+<?php
+if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
+?>
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
+++ b/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
@@ -51,7 +51,7 @@ $child->prop2 = 43;
 var_dump($child->prop2);
 
 ?>
---EXPECT--
-Must not access backing value of property Test::$prop outside its corresponding hooks
-Must not access backing value of property Test::$prop outside its corresponding hooks
+--EXPECTF--
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
 int(43)

--- a/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
+++ b/Zend/tests/property_hooks/backed_delegated_read_wirte.phpt
@@ -2,7 +2,7 @@
 Attempted read/write of backing value in a delegated method throws
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
+if (getenv('SKIP_ASAN')) die('skip ASAN reports stack-overflow');
 ?>
 --INI--
 ; The test may use a large amount of memory on systems with a large stack limit

--- a/Zend/tests/property_hooks/backing_value_simple.phpt
+++ b/Zend/tests/property_hooks/backing_value_simple.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Reads and writes from backing store are only cached for $this
+--XFAIL--
+All reads/writes would now indicate direct, which _kind of_ makes sense.
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/backing_value_simple.phpt
+++ b/Zend/tests/property_hooks/backing_value_simple.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Reads and writes from backing store are only cached for $this
---XFAIL--
-All reads/writes would now indicate direct, which _kind of_ makes sense.
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/parent_get_plain_zpp.phpt
+++ b/Zend/tests/property_hooks/parent_get_plain_zpp.phpt
@@ -24,4 +24,4 @@ try {
 
 ?>
 --EXPECT--
-get() expects exactly 0 arguments, 1 given
+A::$prop::get() expects exactly 0 arguments, 1 given

--- a/Zend/tests/property_hooks/parent_set_plain_zpp.phpt
+++ b/Zend/tests/property_hooks/parent_set_plain_zpp.phpt
@@ -24,4 +24,4 @@ try {
 
 ?>
 --EXPECT--
-set() expects exactly 1 argument, 2 given
+A::$prop::set() expects exactly 1 argument, 2 given

--- a/Zend/tests/property_hooks/parent_superfluous_args.phpt
+++ b/Zend/tests/property_hooks/parent_superfluous_args.phpt
@@ -47,5 +47,5 @@ try {
 --EXPECT--
 int(42)
 NULL
-set() expects exactly 1 argument, 2 given
-get() expects exactly 0 arguments, 1 given
+A::$backed::set() expects exactly 1 argument, 2 given
+A::$backed::get() expects exactly 0 arguments, 1 given

--- a/Zend/tests/property_hooks/read_sibling_backing_value.phpt
+++ b/Zend/tests/property_hooks/read_sibling_backing_value.phpt
@@ -21,5 +21,5 @@ try {
 }
 
 ?>
---EXPECT--
-Must not access backing value of property Test::$a outside its corresponding hooks
+--EXPECTF--
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/property_hooks/read_sibling_backing_value.phpt
+++ b/Zend/tests/property_hooks/read_sibling_backing_value.phpt
@@ -4,6 +4,9 @@ Attempted read/write of backing value in sibling property hook fails
 <?php
 if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
 ?>
+--INI--
+; The test may use a large amount of memory on systems with a large stack limit
+memory_limit=2G
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/read_sibling_backing_value.phpt
+++ b/Zend/tests/property_hooks/read_sibling_backing_value.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Attempted read/write of backing value in sibling property hook fails
+--SKIPIF--
+<?php
+if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
+?>
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/read_sibling_backing_value.phpt
+++ b/Zend/tests/property_hooks/read_sibling_backing_value.phpt
@@ -2,7 +2,7 @@
 Attempted read/write of backing value in sibling property hook fails
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
+if (getenv('SKIP_ASAN')) die('skip ASAN reports stack-overflow');
 ?>
 --INI--
 ; The test may use a large amount of memory on systems with a large stack limit

--- a/Zend/tests/property_hooks/virtual_read_write.phpt
+++ b/Zend/tests/property_hooks/virtual_read_write.phpt
@@ -2,7 +2,7 @@
 Attempted read/write of virtual property backing value throws
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
+if (getenv('SKIP_ASAN')) die('skip ASAN reports stack-overflow');
 ?>
 --INI--
 ; The test may use a large amount of memory on systems with a large stack limit

--- a/Zend/tests/property_hooks/virtual_read_write.phpt
+++ b/Zend/tests/property_hooks/virtual_read_write.phpt
@@ -35,6 +35,6 @@ try {
 }
 
 ?>
---EXPECT--
-Must not write to virtual property Test::$prop
-Must not read from virtual property Test::$prop
+--EXPECTF--
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/property_hooks/virtual_read_write.phpt
+++ b/Zend/tests/property_hooks/virtual_read_write.phpt
@@ -4,6 +4,9 @@ Attempted read/write of virtual property backing value throws
 <?php
 if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
 ?>
+--INI--
+; The test may use a large amount of memory on systems with a large stack limit
+memory_limit=2G
 --FILE--
 <?php
 

--- a/Zend/tests/property_hooks/virtual_read_write.phpt
+++ b/Zend/tests/property_hooks/virtual_read_write.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Attempted read/write of virtual property backing value throws
+--SKIPIF--
+<?php
+if (getenv('SKIP_ASAN')) die('skip FIXME Tweak stack size');
+?>
 --FILE--
 <?php
 

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8516,7 +8516,6 @@ static void zend_compile_property_hooks(
 		}
 	}
 
-	ce->ce_flags |= ZEND_ACC_USE_GUARDS;
 	ce->num_hooked_props++;
 
 	if (!ce->get_iterator) {

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -627,7 +627,7 @@ ZEND_COLD static void zend_typed_property_uninitialized_access(const zend_proper
 static ZEND_FUNCTION(zend_parent_hook_get_trampoline);
 static ZEND_FUNCTION(zend_parent_hook_set_trampoline);
 
-static bool is_in_hook(const zend_property_info *prop_info)
+bool zend_is_in_hook(const zend_property_info *prop_info)
 {
 	zend_execute_data *execute_data = EG(current_execute_data);
 	if (!execute_data || !EX(func) || !EX(func)->common.prop_info) {
@@ -651,7 +651,7 @@ static bool zend_call_get_hook(
 	const zend_property_info *prop_info, zend_string *prop_name,
 	zend_function *get, zend_object *zobj, zval *rv)
 {
-	if (is_in_hook(prop_info)) {
+	if (zend_is_in_hook(prop_info)) {
 		if (UNEXPECTED(prop_info->flags & ZEND_ACC_VIRTUAL)) {
 			zend_throw_no_prop_backing_value_access(zobj->ce->name, prop_name, /* is_read */ true);
 		}
@@ -1032,7 +1032,7 @@ found:;
 			goto try_again;
 		}
 
-		if (is_in_hook(prop_info)) {
+		if (zend_is_in_hook(prop_info)) {
 			if (prop_info->flags & ZEND_ACC_VIRTUAL) {
 				zend_throw_no_prop_backing_value_access(zobj->ce->name, name, /* is_read */ false);
 				variable_ptr = &EG(error_zval);

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -627,7 +627,7 @@ ZEND_COLD static void zend_typed_property_uninitialized_access(const zend_proper
 static ZEND_FUNCTION(zend_parent_hook_get_trampoline);
 static ZEND_FUNCTION(zend_parent_hook_set_trampoline);
 
-bool zend_is_in_hook(const zend_property_info *prop_info, const zend_object *obj)
+static bool zend_is_in_hook(const zend_property_info *prop_info)
 {
 	zend_execute_data *execute_data = EG(current_execute_data);
 	if (!execute_data || !EX(func) || !EX(func)->common.prop_info) {
@@ -636,20 +636,14 @@ bool zend_is_in_hook(const zend_property_info *prop_info, const zend_object *obj
 
 	const zend_property_info *parent_info = EX(func)->common.prop_info;
 	ZEND_ASSERT(prop_info->prototype && parent_info->prototype);
-	return prop_info->prototype == parent_info->prototype
-		&& Z_OBJ(EX(This)) == obj;
+	return prop_info->prototype == parent_info->prototype;
 }
 
-static bool zend_is_guaranteed_hook_call(const zend_property_info *prop_info)
+static bool zend_should_call_hook(const zend_property_info *prop_info, const zend_object *obj)
 {
-	zend_execute_data *execute_data = EG(current_execute_data);
-	if (!execute_data || !EX(func) || !EX(func)->common.prop_info) {
-		return true;
-	}
-
-	const zend_property_info *parent_info = EX(func)->common.prop_info;
-	ZEND_ASSERT(prop_info->prototype && parent_info->prototype);
-	return prop_info->prototype != parent_info->prototype;
+	return !zend_is_in_hook(prop_info)
+		/* execute_data and This are guaranteed to be set if zend_is_in_hook() returns true. */
+		|| Z_OBJ(EG(current_execute_data)->This) != obj;
 }
 
 static ZEND_COLD void zend_throw_no_prop_backing_value_access(zend_string *class_name, zend_string *prop_name, bool is_read)
@@ -663,7 +657,7 @@ static bool zend_call_get_hook(
 	const zend_property_info *prop_info, zend_string *prop_name,
 	zend_function *get, zend_object *zobj, zval *rv)
 {
-	if (zend_is_in_hook(prop_info, zobj)) {
+	if (!zend_should_call_hook(prop_info, zobj)) {
 		if (UNEXPECTED(prop_info->flags & ZEND_ACC_VIRTUAL)) {
 			zend_throw_no_prop_backing_value_access(zobj->ce->name, prop_name, /* is_read */ true);
 		}
@@ -807,7 +801,7 @@ try_again:
 		if (EXPECTED(zend_execute_ex == execute_ex
 		 && zobj->ce->default_object_handlers->read_property == zend_std_read_property
 		 && !zobj->ce->create_object
-		 && zend_is_guaranteed_hook_call(prop_info)
+		 && !zend_is_in_hook(prop_info)
 		 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE))) {
 			ZEND_SET_PROPERTY_HOOK_SIMPLE_GET(cache_slot);
 		}
@@ -1052,7 +1046,7 @@ found:;
 			goto try_again;
 		}
 
-		if (zend_is_in_hook(prop_info, zobj)) {
+		if (!zend_should_call_hook(prop_info, zobj)) {
 			if (prop_info->flags & ZEND_ACC_VIRTUAL) {
 				zend_throw_no_prop_backing_value_access(zobj->ce->name, name, /* is_read */ false);
 				variable_ptr = &EG(error_zval);

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -798,7 +798,8 @@ try_again:
 			goto try_again;
 		}
 
-		if (EXPECTED(zend_execute_ex == execute_ex
+		if (EXPECTED(cache_slot
+		 && zend_execute_ex == execute_ex
 		 && zobj->ce->default_object_handlers->read_property == zend_std_read_property
 		 && !zobj->ce->create_object
 		 && !zend_is_in_hook(prop_info)

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -297,8 +297,6 @@ ZEND_API zend_function *zend_get_property_hook_trampoline(
 	const zend_property_info *prop_info,
 	zend_property_hook_kind kind, zend_string *prop_name);
 
-bool zend_is_in_hook(const zend_property_info *prop_info, const zend_object *obj);
-
 #define zend_release_properties(ht) do { \
 	if ((ht) && !(GC_FLAGS(ht) & GC_IMMUTABLE) && !GC_DELREF(ht)) { \
 		zend_array_destroy(ht); \

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -32,18 +32,21 @@ struct _zend_property_info;
 
 #define ZEND_DYNAMIC_PROPERTY_OFFSET               ((uintptr_t)(intptr_t)(-1))
 
-#define IS_VALID_PROPERTY_OFFSET(offset)           ((intptr_t)(offset) >= 8)
+#define IS_VALID_PROPERTY_OFFSET(offset)           ((intptr_t)(offset) >= 16)
 #define IS_WRONG_PROPERTY_OFFSET(offset)           ((intptr_t)(offset) == 0)
 #define IS_HOOKED_PROPERTY_OFFSET(offset) \
-	((intptr_t)(offset) > 0 && (intptr_t)(offset) < 8)
+	((intptr_t)(offset) > 0 && (intptr_t)(offset) < 16)
 #define IS_DYNAMIC_PROPERTY_OFFSET(offset)         ((intptr_t)(offset) < 0)
 
 #define ZEND_PROPERTY_HOOK_SIMPLE_READ_BIT 2u
 #define ZEND_PROPERTY_HOOK_SIMPLE_WRITE_BIT 4u
+#define ZEND_PROPERTY_HOOK_SIMPLE_GET_BIT 8u
 #define ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(offset) \
 	(((offset) & ZEND_PROPERTY_HOOK_SIMPLE_READ_BIT) != 0)
 #define ZEND_IS_PROPERTY_HOOK_SIMPLE_WRITE(offset) \
 	(((offset) & ZEND_PROPERTY_HOOK_SIMPLE_WRITE_BIT) != 0)
+#define ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(offset) \
+	(((offset) & ZEND_PROPERTY_HOOK_SIMPLE_GET_BIT) != 0)
 #define ZEND_SET_PROPERTY_HOOK_SIMPLE_READ(cache_slot) \
 	do { \
 		void **__cache_slot = (cache_slot); \
@@ -58,10 +61,17 @@ struct _zend_property_info;
 			CACHE_PTR_EX(__cache_slot + 1, (void*)((uintptr_t)CACHED_PTR_EX(__cache_slot + 1) | ZEND_PROPERTY_HOOK_SIMPLE_WRITE_BIT)); \
 		} \
 	} while (0)
+#define ZEND_SET_PROPERTY_HOOK_SIMPLE_GET(cache_slot) \
+	do { \
+		void **__cache_slot = (cache_slot); \
+		if (__cache_slot) { \
+			CACHE_PTR_EX(__cache_slot + 1, (void*)((uintptr_t)CACHED_PTR_EX(__cache_slot + 1) | ZEND_PROPERTY_HOOK_SIMPLE_GET_BIT)); \
+		} \
+	} while (0)
 
 #define IS_UNKNOWN_DYNAMIC_PROPERTY_OFFSET(offset) (offset == ZEND_DYNAMIC_PROPERTY_OFFSET)
-#define ZEND_DECODE_DYN_PROP_OFFSET(offset)        ((uintptr_t)(-(intptr_t)(offset) - 8))
-#define ZEND_ENCODE_DYN_PROP_OFFSET(offset)        ((uintptr_t)(-((intptr_t)(offset) + 8)))
+#define ZEND_DECODE_DYN_PROP_OFFSET(offset)        ((uintptr_t)(-(intptr_t)(offset) - 16))
+#define ZEND_ENCODE_DYN_PROP_OFFSET(offset)        ((uintptr_t)(-((intptr_t)(offset) + 16)))
 
 
 /* Used to fetch property from the object, read-only */

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -287,6 +287,8 @@ ZEND_API zend_function *zend_get_property_hook_trampoline(
 	const zend_property_info *prop_info,
 	zend_property_hook_kind kind, zend_string *prop_name);
 
+bool zend_is_in_hook(const zend_property_info *prop_info);
+
 #define zend_release_properties(ht) do { \
 	if ((ht) && !(GC_FLAGS(ht) & GC_IMMUTABLE) && !GC_DELREF(ht)) { \
 		zend_array_destroy(ht); \

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -287,7 +287,7 @@ ZEND_API zend_function *zend_get_property_hook_trampoline(
 	const zend_property_info *prop_info,
 	zend_property_hook_kind kind, zend_string *prop_name);
 
-bool zend_is_in_hook(const zend_property_info *prop_info);
+bool zend_is_in_hook(const zend_property_info *prop_info, const zend_object *obj);
 
 #define zend_release_properties(ht) do { \
 	if ((ht) && !(GC_FLAGS(ht) & GC_IMMUTABLE) && !GC_DELREF(ht)) { \

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2091,8 +2091,9 @@ ZEND_VM_C_LABEL(fetch_obj_r_fast_copy):
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						ZEND_VM_C_GOTO(fetch_obj_r_simple);
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2091,10 +2091,7 @@ ZEND_VM_C_LABEL(fetch_obj_r_fast_copy):
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						ZEND_VM_C_GOTO(fetch_obj_r_simple);
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6695,26 +6695,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -9261,26 +9259,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -11749,26 +11745,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -16177,26 +16171,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -17668,26 +17660,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -19073,26 +19063,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -33709,26 +33697,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -35866,26 +35852,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -38500,26 +38484,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -42868,26 +42850,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -46810,26 +46790,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 
@@ -52298,26 +52276,24 @@ fetch_obj_r_fast_copy:
 					 && !zend_is_in_hook(prop_info)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
+
 						zend_execute_data *call = zend_vm_stack_push_call_frame(
 							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
 							hook, 0, zobj);
-						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
-						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
-							init_func_run_time_cache(&hook->op_array);
-						}
 						call->prev_execute_data = execute_data;
-						execute_data = call;
+						call->call = NULL;
+						call->return_value = EX_VAR(opline->result.var);
+						call->run_time_cache = RUN_TIME_CACHE(&hook->op_array);
 
-						EX(call) = NULL;
-						EX(return_value) = EX_VAR(opline->result.var);
-						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						execute_data = call;
 						EG(current_execute_data) = execute_data;
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
 						EX(opline) = hook->op_array.opcodes;
 #endif
-
 						LOAD_OPLINE_EX();
 
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6698,9 +6698,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_CONST & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_CONST & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -6708,6 +6713,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -9262,9 +9269,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_CONST & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_CONST & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -9272,6 +9284,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -11748,9 +11762,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_CONST & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_CONST & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -11758,6 +11777,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -16174,9 +16195,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if ((IS_TMP_VAR|IS_VAR) & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if ((IS_TMP_VAR|IS_VAR) & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -16184,6 +16210,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -17663,9 +17691,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if ((IS_TMP_VAR|IS_VAR) & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if ((IS_TMP_VAR|IS_VAR) & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -17673,6 +17706,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -19066,9 +19101,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if ((IS_TMP_VAR|IS_VAR) & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if ((IS_TMP_VAR|IS_VAR) & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -19076,6 +19116,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -33700,9 +33742,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_UNUSED & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_UNUSED & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -33710,6 +33757,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -35855,9 +35904,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_UNUSED & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_UNUSED & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -35865,6 +35919,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -38487,9 +38543,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_UNUSED & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_UNUSED & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -38497,6 +38558,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -42853,9 +42916,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_CV & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_CV & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -42863,6 +42931,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -46793,9 +46863,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_CV & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_CV & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -46803,6 +46878,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else
@@ -52279,9 +52356,14 @@ fetch_obj_r_fast_copy:
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
 
-						zend_execute_data *call = zend_vm_stack_push_call_frame(
-							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
-							hook, 0, zobj);
+						uint32_t call_info = ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS;
+						if (IS_CV & IS_CV) {
+							GC_ADDREF(zobj);
+						}
+						if (IS_CV & (IS_CV|IS_VAR|IS_TMP_VAR)) {
+							call_info |= ZEND_CALL_RELEASE_THIS;
+						}
+						zend_execute_data *call = zend_vm_stack_push_call_frame(call_info, hook, 0, zobj);
 						call->prev_execute_data = execute_data;
 						call->call = NULL;
 						call->return_value = EX_VAR(opline->result.var);
@@ -52289,6 +52371,8 @@ fetch_obj_r_fast_copy:
 
 						execute_data = call;
 						EG(current_execute_data) = execute_data;
+						zend_init_cvs(0, hook->op_array.last_var EXECUTE_DATA_CC);
+
 #if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
 						opline = hook->op_array.opcodes;
 #else

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6691,10 +6691,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -9263,10 +9260,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -11757,10 +11751,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -16191,10 +16182,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -17688,10 +17676,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -19099,10 +19084,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -33741,10 +33723,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -35904,10 +35883,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -38544,10 +38520,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -42918,10 +42891,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -46866,10 +46836,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));
@@ -52360,10 +52327,7 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zend_execute_ex == execute_ex)
-					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info, zobj)
-					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+					} else if (EXPECTED(ZEND_IS_PROPERTY_HOOK_SIMPLE_GET(prop_offset))) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
 						ZEND_ASSERT(RUN_TIME_CACHE(&hook->op_array));

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6691,8 +6691,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -9262,8 +9263,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -11755,8 +11757,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -16188,8 +16191,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -17684,8 +17688,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -19094,8 +19099,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -33735,8 +33741,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -35897,8 +35904,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -38536,8 +38544,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -42909,8 +42918,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -46856,8 +46866,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
@@ -52349,8 +52360,9 @@ fetch_obj_r_fast_copy:
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
-					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
-					 && !zend_is_in_hook(prop_info)
+					} else if (EXPECTED(zend_execute_ex == execute_ex)
+					 && EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info, zobj)
 					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
 						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
 						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6687,10 +6687,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -9225,10 +9253,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -11685,10 +11741,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -16085,10 +16169,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -17548,10 +17660,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -18925,10 +19065,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -33533,10 +33701,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -35662,10 +35858,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -38268,10 +38492,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -42608,10 +42860,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -46522,10 +46802,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {
@@ -51982,10 +52290,38 @@ fetch_obj_r_fast_copy:
 						}
 					}
 				} else if (UNEXPECTED(IS_HOOKED_PROPERTY_OFFSET(prop_offset))) {
+					zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 					if (ZEND_IS_PROPERTY_HOOK_SIMPLE_READ(prop_offset)) {
-						zend_property_info *prop_info = CACHED_PTR_EX(cache_slot + 2);
 						prop_offset = prop_info->offset;
 						goto fetch_obj_r_simple;
+					} else if (EXPECTED(zobj->handlers->read_property == zend_std_read_property)
+					 && !zend_is_in_hook(prop_info)
+					 && !(prop_info->hooks[ZEND_PROPERTY_HOOK_GET]->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)) {
+						zend_function *hook = prop_info->hooks[ZEND_PROPERTY_HOOK_GET];
+						zend_execute_data *call = zend_vm_stack_push_call_frame(
+							ZEND_CALL_NESTED_FUNCTION | ZEND_CALL_HAS_THIS,
+							hook, 0, zobj);
+						ZEND_ASSERT(hook->type == ZEND_USER_FUNCTION);
+						if (UNEXPECTED(!RUN_TIME_CACHE(&hook->op_array))) {
+							init_func_run_time_cache(&hook->op_array);
+						}
+						call->prev_execute_data = execute_data;
+						execute_data = call;
+
+						EX(call) = NULL;
+						EX(return_value) = EX_VAR(opline->result.var);
+						EX(run_time_cache) = RUN_TIME_CACHE(&hook->op_array);
+						EG(current_execute_data) = execute_data;
+#if defined(ZEND_VM_IP_GLOBAL_REG) && ((ZEND_VM_KIND == ZEND_VM_KIND_CALL) || (ZEND_VM_KIND == ZEND_VM_KIND_HYBRID))
+						opline = hook->op_array.opcodes;
+#else
+						EX(opline) = hook->op_array.opcodes;
+#endif
+
+						LOAD_OPLINE_EX();
+
+
+						ZEND_VM_ENTER_EX();
 					}
 					/* Fall through to read_property for hooks. */
 				} else if (EXPECTED(zobj->properties != NULL)) {

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5851,25 +5851,8 @@ ZEND_METHOD(ReflectionProperty, getRawValue)
 		RETURN_THROWS();
 	}
 
-	zend_internal_function func_copy;
-	zend_function *func_backup = EX(func);
-	func_copy = EX(func)->internal_function;
-	func_copy.prop_info = ref->prop;
-	EX(func) = (zend_function *) &func_copy;
-
-	zval rv;
-	zval *member_p = zend_read_property_ex(intern->ce, Z_OBJ_P(object), ref->unmangled_name, 0, &rv);
-
-	EX(func) = func_backup;
-
-	if (member_p != &rv) {
-		RETURN_COPY_DEREF(member_p);
-	} else {
-		if (Z_ISREF_P(member_p)) {
-			zend_unwrap_reference(member_p);
-		}
-		RETURN_COPY_VALUE(member_p);
-	}
+	zend_function *func = zend_get_property_hook_trampoline(ref->prop, ZEND_PROPERTY_HOOK_GET, ref->unmangled_name);
+	zend_call_known_instance_method_with_0_params(func, Z_OBJ_P(object), return_value);
 }
 
 ZEND_METHOD(ReflectionProperty, setRawValue)
@@ -5890,15 +5873,8 @@ ZEND_METHOD(ReflectionProperty, setRawValue)
 		RETURN_THROWS();
 	}
 
-	zend_internal_function func_copy;
-	zend_function *func_backup = EX(func);
-	func_copy = EX(func)->internal_function;
-	func_copy.prop_info = ref->prop;
-	EX(func) = (zend_function *) &func_copy;
-
-	zend_update_property_ex(intern->ce, Z_OBJ_P(object), ref->unmangled_name, value);
-
-	EX(func) = func_backup;
+	zend_function *func = zend_get_property_hook_trampoline(ref->prop, ZEND_PROPERTY_HOOK_SET, ref->unmangled_name);
+	zend_call_known_instance_method_with_1_params(func, Z_OBJ_P(object), NULL, value);
 }
 
 /* {{{ Returns true if property was initialized */

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5851,30 +5851,16 @@ ZEND_METHOD(ReflectionProperty, getRawValue)
 		RETURN_THROWS();
 	}
 
-	uint32_t *guard = NULL;
-	uint32_t guard_backup;
 	zend_internal_function func_copy;
-	zend_function *func_backup = NULL;
-	if (Z_OBJCE_P(object)->ce_flags & ZEND_ACC_USE_GUARDS) {
-		guard = zend_get_property_guard(Z_OBJ_P(object), ref->unmangled_name);
-		guard_backup = *guard;
-		*guard |= ZEND_GUARD_PROPERTY_HOOK;
-
-		func_backup = EX(func);
-		func_copy = EX(func)->internal_function;
-		func_copy.prop_info = ref->prop;
-		EX(func) = (zend_function *) &func_copy;
-	}
+	zend_function *func_backup = EX(func);
+	func_copy = EX(func)->internal_function;
+	func_copy.prop_info = ref->prop;
+	EX(func) = (zend_function *) &func_copy;
 
 	zval rv;
 	zval *member_p = zend_read_property_ex(intern->ce, Z_OBJ_P(object), ref->unmangled_name, 0, &rv);
 
-	if (guard) {
-		*guard = guard_backup;
-	}
-	if (func_backup) {
-		EX(func) = func_backup;
-	}
+	EX(func) = func_backup;
 
 	if (member_p != &rv) {
 		RETURN_COPY_DEREF(member_p);
@@ -5904,29 +5890,15 @@ ZEND_METHOD(ReflectionProperty, setRawValue)
 		RETURN_THROWS();
 	}
 
-	uint32_t *guard = NULL;
-	uint32_t guard_backup;
 	zend_internal_function func_copy;
-	zend_function *func_backup = NULL;
-	if (Z_OBJCE_P(object)->ce_flags & ZEND_ACC_USE_GUARDS) {
-		guard = zend_get_property_guard(Z_OBJ_P(object), ref->unmangled_name);
-		guard_backup = *guard;
-		*guard |= ZEND_GUARD_PROPERTY_HOOK;
-
-		func_backup = EX(func);
-		func_copy = EX(func)->internal_function;
-		func_copy.prop_info = ref->prop;
-		EX(func) = (zend_function *) &func_copy;
-	}
+	zend_function *func_backup = EX(func);
+	func_copy = EX(func)->internal_function;
+	func_copy.prop_info = ref->prop;
+	EX(func) = (zend_function *) &func_copy;
 
 	zend_update_property_ex(intern->ce, Z_OBJ_P(object), ref->unmangled_name, value);
 
-	if (guard) {
-		*guard = guard_backup;
-	}
-	if (func_backup) {
-		EX(func) = func_backup;
-	}
+	EX(func) = func_backup;
 }
 
 /* {{{ Returns true if property was initialized */


### PR DESCRIPTION
@edorian has measured the performance [1] of property hooks and noted that they have a lather large overhead of around 2.8x compared to a getter function. I looked for various way to improve them. One is already in the main branch (caching simple reads for backing value accesses). This PR implements two more changes:

1. It avoids VM re-entry for simple `get` hooks, namely hooks that don't return references.
2. It avoids guards by relying solely on the stack to check whether we are currently inside the corresponding hook when accessing a property, and recursing otherwise. In practice, this will change an immediate error to a stack overflow when recursively accessing a property through a delegated method called from the hook, which shouldn't matter much.

With these changes, I get down to a 1.1x overhead compared to a getter function.

@arnaud-lb I'd be interested in your feedback. Since 2. is a behavioral change, we will propose this as an amendment RFC.

[1] https://gist.github.com/edorian/356332db2f14dd0b96d44a74b3a2e405#file-output-txt