### PR TITLE
Remove zend_always_inline from zend_string_release

### DIFF
--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -528,3 +528,8 @@ size_t strlcat (char *__restrict dest, const char *restrict src, size_t n)
 	return result;
 }
 #endif
+
+extern inline void zend_string_release(zend_string *s);
+extern inline void zend_string_release_ex(zend_string *s, bool persistent);
+extern inline uint32_t zval_gc_flags(uint32_t gc_type_info);
+extern inline uint32_t zend_gc_delref(zend_refcounted_h *p);

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -341,7 +341,7 @@ static zend_always_inline void zend_string_efree(zend_string *s)
 	efree(s);
 }
 
-static zend_always_inline void zend_string_release(zend_string *s)
+ZEND_API inline void zend_string_release(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		if (GC_DELREF(s) == 0) {
@@ -350,7 +350,7 @@ static zend_always_inline void zend_string_release(zend_string *s)
 	}
 }
 
-static zend_always_inline void zend_string_release_ex(zend_string *s, bool persistent)
+ZEND_API inline void zend_string_release_ex(zend_string *s, bool persistent)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		if (GC_DELREF(s) == 0) {

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -742,7 +742,7 @@ static zend_always_inline uint8_t zval_gc_type(uint32_t gc_type_info) {
 	return (gc_type_info & GC_TYPE_MASK);
 }
 
-static zend_always_inline uint32_t zval_gc_flags(uint32_t gc_type_info) {
+ZEND_API inline uint32_t zval_gc_flags(uint32_t gc_type_info) {
 	return (gc_type_info >> GC_FLAGS_SHIFT) & (GC_FLAGS_MASK >> GC_FLAGS_SHIFT);
 }
 
@@ -1339,7 +1339,7 @@ static zend_always_inline void zend_gc_try_delref(zend_refcounted_h *p) {
 	}
 }
 
-static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
+ZEND_API inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
 	ZEND_ASSERT(p->refcount > 0);
 	ZEND_RC_MOD_CHECK(p);
 	return --(p->refcount);


### PR DESCRIPTION
inline (without static or extern) in C99 allows the compiler to decide to inline or link the function. Inlining in unlikely branches can actually hurt performance, because of increased instruction cache pressure.