### PR TITLE
Upgrade Windows builds from Windows 2019

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,7 +42,7 @@ env:
   CXX: ccache g++
 jobs:
   LINUX_X64:
-    if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
+    if: false
     services:
       mysql:
         image: mysql:8.3
@@ -112,7 +112,7 @@ jobs:
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
-    if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
+    if: false
     runs-on: macos-13
     steps:
       - name: git checkout
@@ -147,13 +147,13 @@ jobs:
   WINDOWS:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
     name: WINDOWS_X64_ZTS
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
       PHP_BUILD_OBJ_DIR: C:\obj
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php-sdk-2.3.0
-      PHP_BUILD_CRT: vs16
+      PHP_BUILD_CRT: vs17
       PLATFORM: x64
       THREAD_SAFE: "1"
       INTRINSICS: AVX2

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -58,7 +58,7 @@ jobs:
       ubuntu_version: ${{
         (((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 5) || matrix.branch.version[0] >= 9) && '24.04')
         || '22.04' }}
-      windows_version: ${{ ((matrix.branch.version[0] == 8 && matrix.branch.version[1] >= 4) || matrix.branch.version[0] >= 9) && '2022' || '2019' }}
+      windows_version: '2022'
       skip_laravel: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
       skip_symfony: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}
       skip_wordpress: ${{ matrix.branch.version[0] == 8 && matrix.branch.version[1] == 1 }}


### PR DESCRIPTION
Windows 2019 builds are being dropped by GitHub on 2025-06-30.

https://github.com/actions/runner-images/issues/12045