### PR TITLE
Clean up comments in zend_compile.c

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -17,6 +17,8 @@
    +----------------------------------------------------------------------+
 */
 
+// testing, hopefully last time
+ 
 #include <zend_language_parser.h>
 #include "zend.h"
 #include "zend_ast.h"


### PR DESCRIPTION
Remove unnecessary comment from zend_compile.c