### PR TITLE
perf stat diff

### DIFF
--- a/Zend/zend_perf_stat.h
+++ b/Zend/zend_perf_stat.h
@@ -1,0 +1,129 @@
+/*
+   +----------------------------------------------------------------------+
+   | Zend Engine                                                          |
+   +----------------------------------------------------------------------+
+   | Copyright © Zend Technologies Ltd., a subsidiary company of          |
+   |     Perforce Software, Inc., and Contributors.                       |
+   +----------------------------------------------------------------------+
+   | This source file is subject to the Modified BSD License that is      |
+   | bundled with this package in the file LICENSE, and is available      |
+   | through the World Wide Web at <https://www.php.net/license/>.        |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_PERF_STAT_H
+#define ZEND_PERF_STAT_H
+
+#include "zend_portability.h"
+
+# if !(HAVE_FCNTL_H && HAVE_SYS_SELECT_H && HAVE_SYS_STAT_H && HAVE_SYS_TIME_H && HAVE_UNISTD_H)
+static void zend_perf_stat_enable(void) {}
+static void zend_perf_stat_disable(void) {}
+# else
+
+# include <fcntl.h>
+# include <sys/select.h>
+# include <sys/stat.h>
+# include <unistd.h>
+
+# define ZPS_CTL_FIFO_ENV "PERF_CTL_FIFO"
+# define ZPS_ACK_FIFO_ENV "PERF_ACK_FIFO"
+
+static int ctl_fd = -2;
+static int ack_fd = -2;
+
+static int zps_open_fifo(const char *env_name, int flags)
+{
+	const char *path = getenv(env_name);
+
+	if (path == NULL || path[0] == '\0') {
+		return -1;
+	}
+
+# ifdef O_CLOEXEC
+	flags |= O_CLOEXEC;
+# endif
+	int fd = open(path, flags | O_NONBLOCK);
+	if (fd < 0) {
+		return -1;
+	}
+
+	struct stat st;
+	if (fstat(fd, &st) != 0 || !S_ISFIFO(st.st_mode)) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+static void zps_init(void)
+{
+	if (ctl_fd == -2) {
+		ctl_fd = zps_open_fifo(ZPS_CTL_FIFO_ENV, O_WRONLY);
+	}
+	if (ack_fd == -2) {
+		ack_fd = zps_open_fifo(ZPS_ACK_FIFO_ENV, O_RDONLY);
+	}
+}
+
+static void zps_wait_ack(void)
+{
+	if (ack_fd < 0) {
+		return;
+	}
+
+	struct timeval timeout;
+	timeout.tv_sec = 1;
+	timeout.tv_usec = 0;
+
+	fd_set readfds;
+	FD_ZERO(&readfds);
+	FD_SET(ack_fd, &readfds);
+	if (select(ack_fd + 1, &readfds, NULL, NULL, &timeout) <= 0) {
+		return;
+	}
+
+	char ack[sizeof("ack\n") - 1];
+	ssize_t bytes_read;
+	while ((bytes_read = read(ack_fd, ack, sizeof(ack))) > 0) {
+		for (ssize_t i = 0; i < bytes_read; i++) {
+			if (ack[i] == '\n') {
+				return;
+			}
+		}
+	}
+}
+
+static void zps_control(const char *command, size_t command_len)
+{
+	zps_init();
+
+	if (ctl_fd < 0) {
+		return;
+	}
+
+	if (write(ctl_fd, command, command_len) != (ssize_t) command_len) {
+		close(ctl_fd);
+		ctl_fd = -1;
+		return;
+	}
+
+	zps_wait_ack();
+}
+
+static void zend_perf_stat_enable(void)
+{
+	static const char command[] = "enable\n";
+
+	zps_control(command, sizeof(command) - 1);
+}
+
+static void zend_perf_stat_disable(void)
+{
+	static const char command[] = "disable\n";
+
+	zps_control(command, sizeof(command) - 1);
+}
+
+# endif
+#endif

--- a/benchmark/perf-stat-diff.php
+++ b/benchmark/perf-stat-diff.php
@@ -1,0 +1,564 @@
+#!/usr/bin/env php
+<?php
+
+// Useful setup for more stable local measurements:
+// echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+// echo 0 | sudo tee /sys/devices/system/cpu/cpufreq/boost
+// echo off | sudo tee /sys/devices/system/cpu/smt/control
+// echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+// echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+// echo 0 | sudo tee /proc/sys/kernel/nmi_watchdog
+
+const DEFAULT_RUNS = 10;
+const DEFAULT_WARMUP_RUNS = 2;
+const DEFAULT_CPU = '7';
+const DEFAULT_WINSOR_PERCENT = 25.0;
+
+const METRICS = [
+    'wall_time' => 'wall time',
+    'L1-dcache-load-misses' => 'L1 misses',
+    'cache-misses' => 'LL misses',
+    'de_no_dispatch_per_slot.no_ops_from_frontend' => 'frontend stalls',
+    'de_no_dispatch_per_slot.backend_stalls' => 'backend stalls',
+    'branch-misses' => 'branch misses',
+];
+
+function fail(string $message, int $statusCode = 1): never {
+    fwrite(STDERR, $message . "\n");
+    exit($statusCode);
+}
+
+function usage(int $statusCode = 2): never {
+    fail(
+        "Usage: ./perf-stat-diff.php [options] <base command> [more commands]\n" .
+        "\n" .
+        "Options:\n" .
+        "  --runs=N       Measured runs per command after warmup (default: " . DEFAULT_RUNS . ")\n" .
+        "  --warmup=N     Warmup runs per command to discard (default: " . DEFAULT_WARMUP_RUNS . ")\n" .
+        "  --cpu=LIST     Pin commands with taskset -c LIST (default: " . DEFAULT_CPU . ")\n" .
+        "  --winsor=PCT   Winsorize PCT from each tail before averaging (default: " . DEFAULT_WINSOR_PERCENT . ")\n" .
+        "  --aslr         Run measured commands with ASLR enabled\n" .
+        "  --control      Use perf FIFO control, compatible with PERF_CTL_FIFO/PERF_CTL_ACK_FIFO\n" .
+        "  --help         Show this help",
+        $statusCode,
+    );
+}
+
+function parse_positive_int(string $name, string $value, bool $allowZero = false): int {
+    if (!ctype_digit($value)) {
+        fail("$name must be an integer" . ($allowZero ? ' >= 0' : ' > 0'));
+    }
+
+    $value = (int) $value;
+    if ($allowZero ? $value < 0 : $value <= 0) {
+        fail("$name must be an integer" . ($allowZero ? ' >= 0' : ' > 0'));
+    }
+
+    return $value;
+}
+
+function parse_percent(string $name, string $value): float {
+    if (!is_numeric($value)) {
+        fail("$name must be a percentage >= 0 and < 50");
+    }
+
+    $value = (float) $value;
+    if ($value < 0.0 || $value >= 50.0) {
+        fail("$name must be a percentage >= 0 and < 50");
+    }
+
+    return $value;
+}
+
+function parse_options(array $argv): array {
+    array_shift($argv);
+
+    $options = [
+        'runs' => DEFAULT_RUNS,
+        'warmup' => DEFAULT_WARMUP_RUNS,
+        'cpu' => DEFAULT_CPU,
+        'winsor' => DEFAULT_WINSOR_PERCENT,
+        'aslr' => false,
+        'control' => false,
+    ];
+    $commands = [];
+
+    foreach ($argv as $arg) {
+        if ($arg === '--help' || $arg === '-h') {
+            usage(0);
+        }
+        if (preg_match('(^--runs=(?<runs>.*)$)', $arg, $matches)) {
+            $options['runs'] = parse_positive_int('--runs', $matches['runs']);
+            continue;
+        }
+        if (preg_match('(^--warmup=(?<warmup>.*)$)', $arg, $matches)) {
+            $options['warmup'] = parse_positive_int('--warmup', $matches['warmup'], true);
+            continue;
+        }
+        if (preg_match('(^--cpu=(?<cpu>.*)$)', $arg, $matches)) {
+            $options['cpu'] = $matches['cpu'];
+            continue;
+        }
+        if (preg_match('(^--winsor=(?<winsor>.*)$)', $arg, $matches)) {
+            $options['winsor'] = parse_percent('--winsor', $matches['winsor']);
+            continue;
+        }
+        if ($arg === '--aslr') {
+            $options['aslr'] = true;
+            continue;
+        }
+        if ($arg === '--control') {
+            $options['control'] = true;
+            continue;
+        }
+        if (str_starts_with($arg, '--')) {
+            fail("Unknown option: $arg");
+        }
+
+        $commands[] = $arg;
+    }
+
+    if (count($commands) === 0) {
+        usage();
+    }
+
+    return [$options, $commands];
+}
+
+function mean(array $values): float {
+    return array_sum($values) / count($values);
+}
+
+function percentile(array $values, float $percentile): float {
+    $count = count($values);
+    $index = ($count - 1) * $percentile;
+    $lower = (int) floor($index);
+    $upper = (int) ceil($index);
+
+    if ($lower === $upper) {
+        return $values[$lower];
+    }
+
+    $weight = $index - $lower;
+    return $values[$lower] * (1.0 - $weight) + $values[$upper] * $weight;
+}
+
+function iqr(array $values): float {
+    $q1 = percentile($values, 0.25);
+    $q3 = percentile($values, 0.75);
+
+    return $q3 - $q1;
+}
+
+function winsorized_mean(array $values, float $percent): float {
+    $count = count($values);
+    $tailCount = (int) floor($count * $percent / 100.0);
+    if ($tailCount !== 0) {
+        $low = $values[$tailCount];
+        $high = $values[$count - $tailCount - 1];
+        for ($i = 0; $i < $tailCount; $i++) {
+            $values[$i] = $low;
+            $values[$count - $i - 1] = $high;
+        }
+    }
+
+    return mean($values);
+}
+
+function format_value(float $value): string {
+    $metricPrefixes = [
+        [1e12, 'T'],
+        [1e9, 'G'],
+        [1e6, 'M'],
+        [1e3, 'k'],
+        [1, ''],
+        [1e-3, 'm'],
+        [1e-6, 'u'],
+        [1e-9, 'n'],
+        [1e-12, 'p'],
+    ];
+
+    $absValue = abs($value);
+    foreach ($metricPrefixes as $i => [$factor, $prefix]) {
+        if ($absValue >= $factor || $i === count($metricPrefixes) - 1) {
+            return number_format($value / $factor, 3) . ' ' . $prefix;
+        }
+    }
+}
+
+function format_duration(float $seconds): string {
+    $absSeconds = abs($seconds);
+
+    if ($absSeconds >= 1.0) {
+        return number_format($seconds, 6) . ' s';
+    }
+    if ($absSeconds >= 1e-3) {
+        return number_format($seconds * 1e3, 3) . ' ms';
+    }
+    if ($absSeconds >= 1e-6) {
+        return number_format($seconds * 1e6, 3) . ' us';
+    }
+    return number_format($seconds * 1e9, 3) . ' ns';
+}
+
+function format_metric_value(string $name, float $value): string {
+    if ($name === 'wall_time') {
+        return format_duration($value);
+    }
+
+    return format_value($value);
+}
+
+function format_percentage(float $value, bool $signed = true): string {
+    return ($signed && $value >= 0.0 ? '+' : '') . number_format($value, 3, '.', '') . '%';
+}
+
+function is_output_terminal(): bool {
+    return function_exists('stream_isatty') && stream_isatty(STDOUT);
+}
+
+function use_ansi_colors(): bool {
+    static $useColors = null;
+    if ($useColors !== null) {
+        return $useColors;
+    }
+
+    $term = getenv('TERM');
+    $useColors = is_output_terminal()
+        && getenv('NO_COLOR') === false
+        && $term !== false
+        && $term !== 'dumb';
+
+    return $useColors;
+}
+
+function colorize(string $value, string $code): string {
+    if (!use_ansi_colors()) {
+        return $value;
+    }
+
+    return "\033[{$code}m{$value}\033[0m";
+}
+
+function print_temp(string $message): void {
+    if (!is_output_terminal()) {
+        return;
+    }
+
+    static $lineLength = 0;
+    if ($lineLength !== 0) {
+        echo use_ansi_colors() ? "\033[2K\r" : str_repeat(' ', $lineLength) . "\r";
+    }
+    echo $message, "\r";
+    flush();
+    $lineLength = strlen($message);
+}
+
+function print_progress(int $max, int $current): void {
+    $length = 30;
+    $progress = (int) floor($length / $max * $current);
+    $filledLength = min($length, $progress);
+    $emptyLength = max(0, $length - $filledLength);
+
+    $bar = str_repeat('█', $filledLength);
+    $bar .= str_repeat('░', $emptyLength);
+
+    print_temp("  $bar $current/$max");
+}
+
+function color_for_relative_delta(float $relative): string {
+    if (abs($relative) < 0.1) {
+        return '';
+    }
+    if ($relative < -0.5) {
+        return '32;1';
+    }
+    if ($relative > 0.5) {
+        return '31;1';
+    }
+    return $relative < 0 ? '36;1' : '33;1';
+}
+
+function normalize_perf_event(string $event): string {
+    return preg_replace('(:u$)', '', trim($event));
+}
+
+function parse_counter_value(string $value, string $event): float {
+    $value = trim($value);
+    if ($value === '<not counted>' || $value === '<not supported>') {
+        fail("perf event is not available: $event");
+    }
+
+    $value = str_replace([',', "'"], '', $value);
+    if (!is_numeric($value)) {
+        fail("Could not parse perf value for $event: $value");
+    }
+
+    return (float) $value;
+}
+
+function parse_perf_running_percent(array $parts, string $event): void {
+    if (!isset($parts[4]) || $parts[4] === '') {
+        return;
+    }
+
+    $runningPercent = rtrim(trim($parts[4]), '%');
+    if (!is_numeric($runningPercent)) {
+        return;
+    }
+
+    if ((float) $runningPercent < 99.999) {
+        fail("perf event was multiplexed: $event ran for $runningPercent% of enabled time");
+    }
+}
+
+function parse_perf_stat(string $stderr, array $expectedEvents): array {
+    $counters = [];
+
+    foreach (explode("\n", $stderr) as $line) {
+        $line = trim($line);
+        if ($line === '') {
+            continue;
+        }
+
+        $parts = explode(';', $line);
+        if (count($parts) < 3) {
+            continue;
+        }
+
+        $event = normalize_perf_event($parts[2]);
+        if (!in_array($event, $expectedEvents, true)) {
+            continue;
+        }
+
+        parse_perf_running_percent($parts, $event);
+        $counters[$event] = ($counters[$event] ?? 0.0) + parse_counter_value($parts[0], $event);
+    }
+
+    foreach ($expectedEvents as $event) {
+        if (!array_key_exists($event, $counters)) {
+            fail("perf output did not contain event: $event");
+        }
+    }
+
+    return $counters;
+}
+
+function parse_elapsed_time(string $stderr): ?float {
+    if (!preg_match('(Elapsed time:\s+(?<seconds>[0-9]+(\.[0-9]+)?)\s+sec)', $stderr, $matches)) {
+        return null;
+    }
+    return (float) $matches['seconds'];
+}
+
+function parse_duration_time(string $stderr): ?float {
+    foreach (explode("\n", $stderr) as $line) {
+        $line = trim($line);
+        if ($line === '') {
+            continue;
+        }
+
+        $parts = explode(';', $line);
+        if (count($parts) < 3) {
+            continue;
+        }
+
+        if (normalize_perf_event($parts[2]) !== 'duration_time') {
+            continue;
+        }
+
+        return parse_counter_value($parts[0], 'duration_time') / 1e9;
+    }
+
+    return null;
+}
+
+function perf_events(): array {
+    return array_values(array_diff(array_keys(METRICS), ['wall_time']));
+}
+
+function run_shell_command(string $cmd, array $env): string {
+    $pipes = null;
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+    $processHandle = proc_open($cmd, $descriptorSpec, $pipes, getcwd(), $env);
+    if (!$processHandle) {
+        fail("Could not start command: $cmd");
+    }
+
+    fclose($pipes[0]);
+    stream_set_blocking($pipes[1], false);
+    stream_set_blocking($pipes[2], false);
+
+    $stderrBuffer = '';
+
+    do {
+        $read = [];
+        if (!feof($pipes[1])) {
+            $read[] = $pipes[1];
+        }
+        if (!feof($pipes[2])) {
+            $read[] = $pipes[2];
+        }
+
+        if ($read !== []) {
+            $write = null;
+            $except = null;
+            $ready = stream_select($read, $write, $except, 1, 0);
+            if ($ready !== false && $ready > 0) {
+                foreach ($read as $stream) {
+                    $chunk = fread($stream, 8192);
+                    if ($chunk === false || $chunk === '') {
+                        continue;
+                    }
+                    if ($stream === $pipes[2]) {
+                        $stderrBuffer .= $chunk;
+                    }
+                }
+            }
+        }
+    } while (!feof($pipes[1]) || !feof($pipes[2]));
+
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $statusCode = proc_close($processHandle);
+
+    if ($statusCode !== 0) {
+        fwrite(STDERR, $stderrBuffer);
+        fwrite(STDERR, 'Exited with status code ' . $statusCode . "\n");
+        exit($statusCode);
+    }
+
+    return $stderrBuffer;
+}
+
+function build_perf_command(string $cmd, array $options, array $events): string {
+    $eventSpec = implode(',', $events);
+    if (count($events) > 1) {
+        $eventSpec = '{' . $eventSpec . '}';
+    }
+
+    $perf = 'perf stat -x ' . escapeshellarg(';') . ' -e ' . escapeshellarg($eventSpec) . ' -e duration_time';
+    if ($options['control']) {
+        $perf .= ' -D -1 --control fifo:/tmp/perfctl,/tmp/perfack';
+    }
+
+    $perf .= ' -- ' . $cmd;
+
+    if (!$options['aslr']) {
+        $perf = 'setarch -R ' . $perf;
+    }
+
+    if ($options['cpu'] !== '') {
+        $perf = 'taskset -c ' . escapeshellarg($options['cpu']) . ' ' . $perf;
+    }
+
+    return $perf;
+}
+
+function run_perf_stat(string $cmd, array $options): array {
+    $env = array_merge(getenv(), [
+        'PHP_INI_SCAN_DIR' => '',
+        'PERF_CTL_FIFO' => '/tmp/perfctl',
+        'PERF_CTL_ACK_FIFO' => '/tmp/perfack',
+    ]);
+
+    $events = perf_events();
+    $stderr = run_shell_command(build_perf_command($cmd, $options, $events), $env);
+    $elapsedTime = parse_elapsed_time($stderr) ?? parse_duration_time($stderr);
+
+    if ($elapsedTime === null) {
+        fail("perf output did not contain duration_time: $cmd");
+    }
+
+    return ['wall_time' => $elapsedTime] + parse_perf_stat($stderr, $events);
+}
+
+function aggregate_runs(array $runs, float $winsorPercent): array {
+    $results = [];
+    foreach (METRICS as $name => $_label) {
+        $values = array_column($runs, $name);
+        sort($values, SORT_NUMERIC);
+        $iqr = iqr($values);
+        $mean = winsorized_mean($values, $winsorPercent);
+        $results[$name] = [
+            'mean' => $mean,
+            'iqr' => $iqr,
+        ];
+    }
+    return $results;
+}
+
+function print_command_result(
+    string $cmd,
+    array $result,
+    float $winsorPercent,
+    ?string $baseCmd = null,
+    ?array $base = null,
+): void {
+    echo colorize('$', '2'), ' ', colorize($cmd, '1');
+    if ($baseCmd !== null) {
+        echo colorize(' vs ', '2'), colorize($baseCmd, '1');
+    }
+    echo colorize(" (winsor mean, {$winsorPercent}% tails, iqr)", '2'), "\n";
+
+    foreach (METRICS as $name => $label) {
+        $mean = $result[$name]['mean'];
+        $iqr = $result[$name]['iqr'];
+        $value = str_pad(format_metric_value($name, $mean), 12, ' ', STR_PAD_LEFT);
+        $iqrValue = '(' . format_percentage($mean != 0.0 ? 100.0 / $mean * $iqr : 0.0, signed: false) . ')';
+
+        echo '  ', colorize(str_pad($label, 16), '36'), colorize(' = ', '2'), colorize($value, '1'), ' ', colorize($iqrValue, '2');
+        if ($base !== null) {
+            $baseMean = $base[$name]['mean'];
+            $delta = $mean - $baseMean;
+            $relative = $baseMean != 0.0 ? (($mean / $baseMean) - 1.0) * 100.0 : 0.0;
+            $value = str_pad(format_metric_value($name, $delta) . ' (' . format_percentage($relative) . ')', 22, ' ', STR_PAD_LEFT);
+            $color = color_for_relative_delta($relative);
+            echo $color !== '' ? colorize($value, $color) : $value;
+        }
+        echo "\n";
+    }
+}
+
+function main(array $argv): void {
+    [$options, $commands] = parse_options($argv);
+
+    $total = ($options['warmup'] + $options['runs']) * count($commands);
+    $current = 0;
+    $runGroups = [];
+    $results = [];
+
+    for ($run = 0; $run < $options['warmup']; $run++) {
+        for ($i = 0; $i < count($commands); $i++) {
+            print_progress($total, $current++);
+            run_perf_stat($commands[$i], $options);
+        }
+    }
+
+    for ($run = 0; $run < $options['runs']; $run++) {
+        for ($i = 0; $i < count($commands); $i++) {
+            print_progress($total, $current++);
+            $runGroups[$i][] = run_perf_stat($commands[$i], $options);
+        }
+    }
+
+    print_temp('');
+    foreach ($commands as $i => $_cmd) {
+        $results[$i] = aggregate_runs($runGroups[$i], $options['winsor']);
+    }
+
+    foreach ($results as $i => $result) {
+        print_command_result(
+            $commands[$i],
+            $result,
+            $options['winsor'],
+            $i === 0 ? null : $commands[0],
+            $i === 0 ? null : $results[0],
+        );
+        if ($i !== count($results) - 1) {
+            echo "\n";
+        }
+    }
+}
+
+main($argv);

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -95,6 +95,8 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
 # endif
 #endif
 
+#include "zend_perf_stat.h"
+
 #ifndef PHP_WIN32
 /* XXX this will need to change later when threaded fastcgi is implemented.  shane */
 static struct sigaction act, old_term, old_quit, old_int;
@@ -1733,6 +1735,7 @@ int main(int argc, char *argv[])
 	int warmup_repeats = 0;
 	int repeats = 1;
 	int benchmark = 0;
+	bool perf_enabled = false;
 #ifdef HAVE_GETTIMEOFDAY
 	struct timeval start, end;
 #else
@@ -2441,14 +2444,16 @@ do_repeat:
 				}
 			} /* end !cgi && !fastcgi */
 
-#ifdef HAVE_VALGRIND
 			if (warmup_repeats == 0) {
+				zend_perf_stat_enable();
+				perf_enabled = true;
+#ifdef HAVE_VALGRIND
 				CALLGRIND_START_INSTRUMENTATION;
 # ifdef HAVE_VALGRIND_CACHEGRIND_H
 				CACHEGRIND_START_INSTRUMENTATION;
 # endif
-			}
 #endif
+			}
 
 			/* request startup only after we've done all we can to
 			 * get path_translated */
@@ -2568,6 +2573,10 @@ fastcgi_request_done:
 				SG(request_info).query_string = NULL;
 			}
 
+			if (perf_enabled) {
+				zend_perf_stat_disable();
+				perf_enabled = false;
+			}
 #ifdef HAVE_VALGRIND
 			/* We're not interested in measuring shutdown */
 			CALLGRIND_STOP_INSTRUMENTATION;


### PR DESCRIPTION
In conjunction with:

```nix
{
  boot.kernelParams = [
    "isolcpus=domain,managed_irq,7,23"
    "nohz_full=7,23"
    "rcu_nocbs=7,23"
    "irqaffinity=0-6,8-22,24-31"
  ];

  boot.kernel.sysctl = {
    "kernel.perf_event_paranoid" = 1;
    "kernel.nmi_watchdog" = 0;
  };

  services.power-profiles-daemon.enable = false;
  systemd.services.benchmark-cpu-policy = {
    description = "CPU policy for benchmarking";
    wantedBy = [ "multi-user.target" ];
    after = [ "cpufreq.service" ];
    serviceConfig = {
      Type = "oneshot";
      RemainAfterExit = true;
    };
    script = ''
      set -eu
      for cpu in 7 23; do
        policy=/sys/devices/system/cpu/cpufreq/policy$cpu
        [ -w "$policy/scaling_governor" ] && echo performance > "$policy/scaling_governor"
        [ -w "$policy/energy_performance_preference" ] && echo performance > "$policy/energy_performance_preference"
        [ -w "$policy/boost" ] && echo 0 > "$policy/boost"
      done
    '';
  };
}
```

leads to fairly accurate benchmarks on my machine:

```
❯ time benchmark/perf-stat-diff.php --runs=200 --control 'sapi/cgi/php-cgi -T1,20 benchmark/repos/symfony-demo-2.2.3/public/index.php > /dev/null' 'sapi/cgi/php-cgi -T1,20 benchmark/repos/symfony-demo-2.2.3/public/index.php > /dev/null'
$ sapi/cgi/php-cgi -T1,20 benchmark/repos/symfony-demo-2.2.3/public/index.php > /dev/null (winsor mean, 25% tails, iqr)
  wall time        =   116.678 ms (0.206%)
  L1 misses        =     18.980 M (0.478%)
  LL misses        =      6.338 M (1.373%)
  frontend stalls  =      1.410 G (0.573%)
  backend stalls   =    275.934 M (1.867%)
  branch misses    =      4.813 M (0.515%)

$ sapi/cgi/php-cgi -T1,20 benchmark/repos/symfony-demo-2.2.3/public/index.php > /dev/null vs sapi/cgi/php-cgi -T1,20 benchmark/repos/symfony-demo-2.2.3/public/index.php > /dev/null (winsor mean, 25% tails, iqr)
  wall time        =   116.660 ms (0.169%)  -17.375 us (-0.015%)
  L1 misses        =     18.965 M (0.873%)   -15.716 k (-0.083%)
  LL misses        =      6.337 M (1.492%)   -955.470  (-0.015%)
  frontend stalls  =      1.410 G (0.840%)  -233.622 k (-0.017%)
  backend stalls   =    276.170 M (1.675%)   236.670 k (+0.086%)
  branch misses    =      4.812 M (0.771%)   -899.620  (-0.019%)

________________________________________________________
Executed in  110.60 secs    fish           external
   usr time   90.19 secs  802.00 micros   90.19 secs
   sys time   20.08 secs  928.00 micros   20.08 secs
```